### PR TITLE
Adopt the DH parts from the base spec

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -6,8 +6,6 @@ machine:
 
 checkout:
   post:
-    - git submodule sync
-    - git submodule update --init
     - git fetch origin gh-pages --depth 10
 
 dependencies:
@@ -21,6 +19,6 @@ test:
 
 deployment:
   production:
-    branch: master
+    branch: /.*/
     commands:
       - make ghpages


### PR DESCRIPTION
In httpwg/http-extensions#218 I have proposed the removal of the Diffie-Hellman pieces.  This PR adopts the parts that were removed from the base spec that webpush needs.  

In the process, I've had to make a bunch of changes.  It loses a bit of generality, which makes things easier to follow, which I've tried to capitalize on by being a lot more explicit about the overall process.

[Preview the changes](https://webpush-wg.github.io/webpush-encryption/simple_base/).

@beverloo, @jrconlin, @marco-c would you mind reviewing this change to see that I haven't messed something up?
