### PR TITLE
Put the DH public key in the message.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,5 +5,5 @@ ifneq (,$(shell git submodule status lib 2>/dev/null))
 	git submodule sync
 	git submodule update --init
 else
-	git clone --depth 10 -b master https://github.com/martinthomson/i-d-template.git lib
+	git clone --depth 10 -b subcogh https://github.com/martinthomson/i-d-template.git lib
 endif

--- a/circle.yml
+++ b/circle.yml
@@ -1,17 +1,18 @@
 machine:
-  python:
-    version: 2.7.6
-  ruby:
-    version: 2.2.3
+  environment:
+    GOPATH: "${HOME}/${CIRCLE_PROJECT_REPONAME}/.go_workspace"
+    mmark_src: github.com/miekg/mmark/mmark
+    mmark: ./mmark
 
 checkout:
   post:
-    - git fetch origin gh-pages --depth 10
+    - git fetch origin gh-pages --depth 8
 
 dependencies:
   pre:
     - pip install xml2rfc
-    - gem install kramdown-rfc2629
+    - if head -1 -q *.md | grep '^\-\-\-' >/dev/null 2>&1; then gem install --no-doc kramdown-rfc2629; fi
+    - if head -1 -q *.md | grep '^%%%' >/dev/null 2>&1; then go get "$mmark_src" && go build "$mmark_src"; fi
 
 test:
   override:

--- a/draft-ietf-webpush-encryption.md
+++ b/draft-ietf-webpush-encryption.md
@@ -184,9 +184,7 @@ key pair on the same P-256 curve.
 
 The ECDH public key for the Application Server is included as the "keyid"
 parameter in the encrypted content coding header (see Section 2.1 of
-{{!I-D.ietf-httpbis-encryption-encoding}}.  The uncompressed point form defined
-in {{X9.62}} (that is, a 65 octet sequence that starts with a 0x04 octet) forms
-the entirety of the "keyid".
+{{!I-D.ietf-httpbis-encryption-encoding}}.
 
 An Application combines its ECDH private key with the public key provided by the
 User Agent using the process described in {{ECDH}}; on receipt of the push
@@ -280,7 +278,9 @@ header to a size that is greater than the length of the plaintext, plus any
 padding (which is at least 2 octets).
 
 A push message MUST include the application server ECDH public key in the
-`keyid` parameter of the encrypted content coding header.
+`keyid` parameter of the encrypted content coding header.  The uncompressed
+point form defined in {{X9.62}} (that is, a 65 octet sequence that starts with
+a 0x04 octet) forms the entirety of the "keyid".
 
 A push service is not required to support more than 4096 octets of payload body
 (see Section 7.2 of {{!I-D.ietf-webpush-protocol}}).  Absent header (86 octets),


### PR DESCRIPTION
This removes Crypto-Key and moves the DH public key into the keyid field.